### PR TITLE
Enforce numpy version used in the notebooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# needed as pypowsybl 1.5.1 (and below) is not working with numpy 2.0.0 (and above)
+numpy == 1.26.4


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
No notebook can be used as is, as pypowsybl cannot be imported.
Since 16th June, when pypowsybl gets installed in the notebook, numpy 2.0.0 gets installed, which is not (yet) compatible with pypowsybl.


**What is the new behavior (if this is a feature change)?**
numpy 1.26.4 version enforced by a requirements.txt file
