### PR TITLE
updated widget demo: network on a map

### DIFF
--- a/pypowsybl_jupyter_widgets_demo.ipynb
+++ b/pypowsybl_jupyter_widgets_demo.ipynb
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e550558b-452d-424f-b484-79ae60ec35bc",
+   "id": "c5282ea3-1652-4d7f-81cf-36c2d3157dcf",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -92,7 +92,8 @@
     "Display the network explorer widget. \n",
     "* Click on a voltage level from the list to display its NAD and SLD in the two \"Network Area\" and \"Single Line\" tabs. \n",
     "* Both diagrams can be panned and zoomed.\n",
-    "* The NAD is centered on the currently selected voltage level. A 'depth' slider controls the size of the sub-network."
+    "* The NAD is centered on the currently selected voltage level. A 'depth' slider controls the size of the sub-network.\n",
+    "* A third tab, \"Network map\" displays the network’s substations and lines on a map. The map is empty if the network does not contain any geographical data."
    ]
   },
   {
@@ -127,6 +128,50 @@
    "outputs": [],
    "source": [
     "network_explorer(n, vl_id='VL14', depth=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba94b49a-979e-4c70-b66b-5c973556616d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Load a network that contains geographical data, and display it with the network explorer widget, to demonstrate the \"Network map\" tab.\n",
+    "* The optional nominal_voltages_top_tiers_filter parameter can be used to display in the map only the highest n nominal voltages (the default is -1, to display all the voltages).\n",
+    "* In the map, a click on a substation displays a popup list with the substation's voltage levels. This list provides an additional way to navigate the widget to a specific voltage level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5467ab6f-8591-4b7c-a1e5-5b28953bd572",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "microgrid_network = pp.network.load('./data/MicroGridTestConfiguration_T4_BE_BB_Complete_v2.zip', {'iidm.import.cgmes.post-processors': 'cgmesGLImport'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87f6a143-6b95-47e6-b0f4-8e561b6f31a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "network_explorer(microgrid_network, nominal_voltages_top_tiers_filter=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80f37582-ac8b-4140-83f0-e17eff0b7c95",
+   "metadata": {},
+   "source": [
+    "Please visit the [pypowsybl-jupyter documentation](https://powsybl.readthedocs.io/projects/pypowsybl-jupyter/en/stable/) for detailed information about the widgets and their APIs."
    ]
   }
  ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
The map tab feature is not highlighted in the current notebook.


**What is the new behavior (if this is a feature change)?**
The new notebook extends the demo.  Users are able to load a network with geographical data to be displayed in the explorer widget's map tab.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No